### PR TITLE
[dependabot] Force monday so we have everything at start of the week

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,11 +15,13 @@ updates:
     interval: weekly
     time: "05:00"
     timezone: Europe/Paris
+    day: monday
 - package-ecosystem: docker
   directory: "/"
   schedule:
     interval: weekly
     time: "05:00"
     timezone: Europe/Paris
+    day: monday
   registries:
   - docker-registry-registry-hub-docker-com


### PR DESCRIPTION
## Description
Force dependabot le lundi, pour éviter aux mainteneurs de revenir sur les mises à jour plusieurs fois dans la semaine.

## Ref and pre-requisites
- https://docs.github.com/fr/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#scheduleday