### PR TITLE
Add docker-compose for easier deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM honestica/python:3.12-3187
+FROM python:3.12
 WORKDIR /app
 
 USER root
@@ -10,7 +10,9 @@ RUN pipenv sync --clear --bare --system \
  && rm Pipfile Pipfile.lock
 
 COPY src /app/src/
-
+RUN useradd -m appuser \
+ && chown -R appuser:appuser /app
+ 
 USER appuser
 
 CMD ["uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.8'
+
+services:
+  alert2jira:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: alert2jira
+    ports:
+      - "8000:8000"
+    environment:
+      - JIRA_API_URL=value1
+      - JIRA_USERNAME=value2
+      - JIRA_API_TOKEN=value3
+    


### PR DESCRIPTION
Hi there,

we need the functionality provided by the alert2jira tool, and i just started to evaluate and test it out, maybe wanting to contribute regularly as well. 

For easier deployment, i created a docker-compose file.
For this, i updated the Dockerfile to use the official python image as base, i hope this is fine.

Keep up the good work ;)