### PR TITLE
[docker] Add step to upgrade packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,12 @@ WORKDIR /app
 
 USER root
 
+# Upgrade packages
+RUN set -eux; \
+  apt-get update; \
+  apt-get dist-upgrade -y; \
+  apt-get dist-clean
+
 RUN pip3 install pipenv==2024.4.0
 COPY Pipfile /app
 COPY Pipfile.lock /app
@@ -12,7 +18,7 @@ RUN pipenv sync --clear --bare --system \
 COPY src /app/src/
 RUN useradd -m appuser \
  && chown -R appuser:appuser /app
- 
+
 USER appuser
 
 CMD ["uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
For the moment, the `python:3.12` docker image which is published still have a vulnerability related to CVE-2025-57807
* https://hub.docker.com/layers/library/python/3.12/images/sha256-34972e12cd00724911e444c3ff0f45324692b20bff71f9987d26748d96157ecf

Follow this link:
* https://security-tracker.debian.org/tracker/CVE-2025-57807

This CVE has been fixed on `7.1.1.43+dfsg1-1+deb13u2`:
* https://metadata.ftp-master.debian.org/changelogs//main/i/imagemagick/imagemagick_7.1.1.43+dfsg1-1+deb13u2_changelog

As a quick-win, we force an upgrade of all Debian packages to fix this CVE